### PR TITLE
Fix send_message by fixing issue with protobuf types

### DIFF
--- a/yowsup/layers/axolotl/layer_send.py
+++ b/yowsup/layers/axolotl/layer_send.py
@@ -225,7 +225,7 @@ class AxolotlSendLayer(AxolotlBaseLayer):
 
     def serializeTextToProtobuf(self, node, message = None):
         m = message or Message()
-        m.conversation = node.getChild("body").getData()
+        m.conversation = str.encode(node.getChild("body").getData())
         return m
 
     def serializeMediaToProtobuf(self, mediaNode, message = None):

--- a/yowsup/layers/protocol_messages/proto/wa.proto
+++ b/yowsup/layers/protocol_messages/proto/wa.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package com.whatsapp.proto;
 
 message Message {

--- a/yowsup/layers/protocol_messages/proto/wa_pb2.py
+++ b/yowsup/layers/protocol_messages/proto/wa_pb2.py
@@ -3,12 +3,14 @@
 
 import sys
 _b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
-
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
-
+from google.protobuf import symbol_database as _symbol_database
+from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
+
+_sym_db = _symbol_database.Default()
 
 
 
@@ -16,7 +18,10 @@ from google.protobuf import reflection as _reflection
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='wa.proto',
   package='com.whatsapp.proto',
-  serialized_pb=_b('\n\x08wa.proto\x12\x12\x63om.whatsapp.proto\"\x95\x04\n\x07Message\x12\x14\n\x0c\x63onversation\x18\x01 \x01(\t\x12Y\n\x1fsender_key_distribution_message\x18\x02 \x01(\x0b\x32\x30.com.whatsapp.proto.SenderKeyDistributionMessage\x12\x37\n\rimage_message\x18\x03 \x01(\x0b\x32 .com.whatsapp.proto.ImageMessage\x12;\n\x0f\x63ontact_message\x18\x04 \x01(\x0b\x32\".com.whatsapp.proto.ContactMessage\x12=\n\x10location_message\x18\x05 \x01(\x0b\x32#.com.whatsapp.proto.LocationMessage\x12=\n\x10\x64ocument_message\x18\x07 \x01(\x0b\x32#.com.whatsapp.proto.DocumentMessage\x12\x33\n\x0burl_message\x18\x06 \x01(\x0b\x32\x1e.com.whatsapp.proto.UrlMessage\x12\x37\n\raudio_message\x18\x08 \x01(\x0b\x32 .com.whatsapp.proto.AudioMessage\x12\x37\n\rvideo_message\x18\t \x01(\x0b\x32 .com.whatsapp.proto.VideoMessage\"`\n\x1cSenderKeyDistributionMessage\x12\x0f\n\x07groupId\x18\x01 \x02(\t\x12/\n\'axolotl_sender_key_distribution_message\x18\x02 \x02(\x0c\"\xb3\x01\n\x0cImageMessage\x12\x0b\n\x03url\x18\x01 \x02(\x0c\x12\x11\n\tmime_type\x18\x02 \x02(\t\x12\x0f\n\x07\x63\x61ption\x18\x03 \x02(\t\x12\x13\n\x0b\x66ile_sha256\x18\x04 \x02(\x0c\x12\x13\n\x0b\x66ile_length\x18\x05 \x02(\x04\x12\x0e\n\x06height\x18\x06 \x02(\r\x12\r\n\x05width\x18\x07 \x02(\r\x12\x11\n\tmedia_key\x18\x08 \x02(\x0c\x12\x16\n\x0ejpeg_thumbnail\x18\x10 \x02(\x0c\"\xa6\x01\n\x0cVideoMessage\x12\x0b\n\x03url\x18\x01 \x02(\x0c\x12\x11\n\tmime_type\x18\x02 \x02(\t\x12\x13\n\x0b\x66ile_sha256\x18\x03 \x02(\x0c\x12\x13\n\x0b\x66ile_length\x18\x04 \x02(\x04\x12\x10\n\x08\x64uration\x18\x05 \x02(\x04\x12\x11\n\tmedia_key\x18\x06 \x02(\x0c\x12\x0f\n\x07\x63\x61ption\x18\x07 \x02(\t\x12\x16\n\x0ejpeg_thumbnail\x18\x10 \x02(\x0c\"\x8a\x01\n\x0c\x41udioMessage\x12\x0b\n\x03url\x18\x01 \x02(\x0c\x12\x11\n\tmime_type\x18\x02 \x02(\t\x12\x13\n\x0b\x66ile_sha256\x18\x03 \x02(\x0c\x12\x13\n\x0b\x66ile_length\x18\x04 \x02(\x04\x12\x10\n\x08\x64uration\x18\x05 \x02(\x04\x12\x0b\n\x03unk\x18\x06 \x02(\r\x12\x11\n\tmedia_key\x18\x07 \x02(\x0c\"\x8a\x01\n\x0fLocationMessage\x12\x18\n\x10\x64\x65grees_latitude\x18\x01 \x02(\x01\x12\x19\n\x11\x64\x65grees_longitude\x18\x02 \x02(\x01\x12\x0c\n\x04name\x18\x03 \x02(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\x04 \x02(\t\x12\x0b\n\x03url\x18\x05 \x02(\t\x12\x16\n\x0ejpeg_thumbnail\x18\x10 \x02(\x0c\"\xa9\x01\n\x0f\x44ocumentMessage\x12\x0b\n\x03url\x18\x01 \x02(\t\x12\x11\n\tmime_type\x18\x02 \x02(\t\x12\r\n\x05title\x18\x03 \x02(\t\x12\x13\n\x0b\x66ile_sha256\x18\x04 \x02(\x0c\x12\x13\n\x0b\x66ile_length\x18\x05 \x02(\x04\x12\x12\n\npage_count\x18\x06 \x02(\r\x12\x11\n\tmedia_key\x18\x07 \x02(\x0c\x12\x16\n\x0ejpeg_thumbnail\x18\x10 \x02(\x0c\"\x83\x01\n\nUrlMessage\x12\x0c\n\x04text\x18\x01 \x02(\t\x12\x14\n\x0cmatched_text\x18\x02 \x02(\t\x12\x15\n\rcanonical_url\x18\x04 \x02(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x02(\t\x12\r\n\x05title\x18\x06 \x02(\t\x12\x16\n\x0ejpeg_thumbnail\x18\x10 \x02(\x0c\"5\n\x0e\x43ontactMessage\x12\x14\n\x0c\x64isplay_name\x18\x01 \x02(\t\x12\r\n\x05vcard\x18\x10 \x02(\x0c'))
+  syntax='proto2',
+  serialized_pb=_b('\n\x08wa.proto\x12\x12\x63om.whatsapp.proto\"\x95\x04\n\x07Message\x12\x14\n\x0c\x63onversation\x18\x01 \x01(\x0c\x12Y\n\x1fsender_key_distribution_message\x18\x02 \x01(\x0b\x32\x30.com.whatsapp.proto.SenderKeyDistributionMessage\x12\x37\n\rimage_message\x18\x03 \x01(\x0b\x32 .com.whatsapp.proto.ImageMessage\x12;\n\x0f\x63ontact_message\x18\x04 \x01(\x0b\x32\".com.whatsapp.proto.ContactMessage\x12=\n\x10location_message\x18\x05 \x01(\x0b\x32#.com.whatsapp.proto.LocationMessage\x12=\n\x10\x64ocument_message\x18\x07 \x01(\x0b\x32#.com.whatsapp.proto.DocumentMessage\x12\x33\n\x0burl_message\x18\x06 \x01(\x0b\x32\x1e.com.whatsapp.proto.UrlMessage\x12\x37\n\raudio_message\x18\x08 \x01(\x0b\x32 .com.whatsapp.proto.AudioMessage\x12\x37\n\rvideo_message\x18\t \x01(\x0b\x32 .com.whatsapp.proto.VideoMessage\"`\n\x1cSenderKeyDistributionMessage\x12\x0f\n\x07groupId\x18\x01 \x02(\t\x12/\n\'axolotl_sender_key_distribution_message\x18\x02 \x02(\x0c\"\xb3\x01\n\x0cImageMessage\x12\x0b\n\x03url\x18\x01 \x02(\x0c\x12\x11\n\tmime_type\x18\x02 \x02(\t\x12\x0f\n\x07\x63\x61ption\x18\x03 \x02(\t\x12\x13\n\x0b\x66ile_sha256\x18\x04 \x02(\x0c\x12\x13\n\x0b\x66ile_length\x18\x05 \x02(\x04\x12\x0e\n\x06height\x18\x06 \x02(\r\x12\r\n\x05width\x18\x07 \x02(\r\x12\x11\n\tmedia_key\x18\x08 \x02(\x0c\x12\x16\n\x0ejpeg_thumbnail\x18\x10 \x02(\x0c\"\xa6\x01\n\x0cVideoMessage\x12\x0b\n\x03url\x18\x01 \x02(\x0c\x12\x11\n\tmime_type\x18\x02 \x02(\t\x12\x13\n\x0b\x66ile_sha256\x18\x03 \x02(\x0c\x12\x13\n\x0b\x66ile_length\x18\x04 \x02(\x04\x12\x10\n\x08\x64uration\x18\x05 \x02(\x04\x12\x11\n\tmedia_key\x18\x06 \x02(\x0c\x12\x0f\n\x07\x63\x61ption\x18\x07 \x02(\t\x12\x16\n\x0ejpeg_thumbnail\x18\x10 \x02(\x0c\"\x8a\x01\n\x0c\x41udioMessage\x12\x0b\n\x03url\x18\x01 \x02(\x0c\x12\x11\n\tmime_type\x18\x02 \x02(\t\x12\x13\n\x0b\x66ile_sha256\x18\x03 \x02(\x0c\x12\x13\n\x0b\x66ile_length\x18\x04 \x02(\x04\x12\x10\n\x08\x64uration\x18\x05 \x02(\x04\x12\x0b\n\x03unk\x18\x06 \x02(\r\x12\x11\n\tmedia_key\x18\x07 \x02(\x0c\"\x8a\x01\n\x0fLocationMessage\x12\x18\n\x10\x64\x65grees_latitude\x18\x01 \x02(\x01\x12\x19\n\x11\x64\x65grees_longitude\x18\x02 \x02(\x01\x12\x0c\n\x04name\x18\x03 \x02(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\x04 \x02(\t\x12\x0b\n\x03url\x18\x05 \x02(\t\x12\x16\n\x0ejpeg_thumbnail\x18\x10 \x02(\x0c\"\xa9\x01\n\x0f\x44ocumentMessage\x12\x0b\n\x03url\x18\x01 \x02(\t\x12\x11\n\tmime_type\x18\x02 \x02(\t\x12\r\n\x05title\x18\x03 \x02(\t\x12\x13\n\x0b\x66ile_sha256\x18\x04 \x02(\x0c\x12\x13\n\x0b\x66ile_length\x18\x05 \x02(\x04\x12\x12\n\npage_count\x18\x06 \x02(\r\x12\x11\n\tmedia_key\x18\x07 \x02(\x0c\x12\x16\n\x0ejpeg_thumbnail\x18\x10 \x02(\x0c\"\x83\x01\n\nUrlMessage\x12\x0c\n\x04text\x18\x01 \x02(\t\x12\x14\n\x0cmatched_text\x18\x02 \x02(\t\x12\x15\n\rcanonical_url\x18\x04 \x02(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x02(\t\x12\r\n\x05title\x18\x06 \x02(\t\x12\x16\n\x0ejpeg_thumbnail\x18\x10 \x02(\x0c\"5\n\x0e\x43ontactMessage\x12\x14\n\x0c\x64isplay_name\x18\x01 \x02(\t\x12\r\n\x05vcard\x18\x10 \x02(\x0c')
+)
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 
@@ -31,7 +36,7 @@ _MESSAGE = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='conversation', full_name='com.whatsapp.proto.Message.conversation', index=0,
       number=1, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
+      has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -99,7 +104,10 @@ _MESSAGE = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
+  syntax='proto2',
   extension_ranges=[],
+  oneofs=[
+  ],
   serialized_start=33,
   serialized_end=566,
 )
@@ -134,7 +142,10 @@ _SENDERKEYDISTRIBUTIONMESSAGE = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
+  syntax='proto2',
   extension_ranges=[],
+  oneofs=[
+  ],
   serialized_start=568,
   serialized_end=664,
 )
@@ -218,7 +229,10 @@ _IMAGEMESSAGE = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
+  syntax='proto2',
   extension_ranges=[],
+  oneofs=[
+  ],
   serialized_start=667,
   serialized_end=846,
 )
@@ -295,7 +309,10 @@ _VIDEOMESSAGE = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
+  syntax='proto2',
   extension_ranges=[],
+  oneofs=[
+  ],
   serialized_start=849,
   serialized_end=1015,
 )
@@ -365,7 +382,10 @@ _AUDIOMESSAGE = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
+  syntax='proto2',
   extension_ranges=[],
+  oneofs=[
+  ],
   serialized_start=1018,
   serialized_end=1156,
 )
@@ -381,14 +401,14 @@ _LOCATIONMESSAGE = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='degrees_latitude', full_name='com.whatsapp.proto.LocationMessage.degrees_latitude', index=0,
       number=1, type=1, cpp_type=5, label=2,
-      has_default_value=False, default_value=0,
+      has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
       name='degrees_longitude', full_name='com.whatsapp.proto.LocationMessage.degrees_longitude', index=1,
       number=2, type=1, cpp_type=5, label=2,
-      has_default_value=False, default_value=0,
+      has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -428,7 +448,10 @@ _LOCATIONMESSAGE = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
+  syntax='proto2',
   extension_ranges=[],
+  oneofs=[
+  ],
   serialized_start=1159,
   serialized_end=1297,
 )
@@ -505,7 +528,10 @@ _DOCUMENTMESSAGE = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
+  syntax='proto2',
   extension_ranges=[],
+  oneofs=[
+  ],
   serialized_start=1300,
   serialized_end=1469,
 )
@@ -568,7 +594,10 @@ _URLMESSAGE = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
+  syntax='proto2',
   extension_ranges=[],
+  oneofs=[
+  ],
   serialized_start=1472,
   serialized_end=1603,
 )
@@ -603,7 +632,10 @@ _CONTACTMESSAGE = _descriptor.Descriptor(
   ],
   options=None,
   is_extendable=False,
+  syntax='proto2',
   extension_ranges=[],
+  oneofs=[
+  ],
   serialized_start=1605,
   serialized_end=1658,
 )
@@ -626,59 +658,68 @@ DESCRIPTOR.message_types_by_name['DocumentMessage'] = _DOCUMENTMESSAGE
 DESCRIPTOR.message_types_by_name['UrlMessage'] = _URLMESSAGE
 DESCRIPTOR.message_types_by_name['ContactMessage'] = _CONTACTMESSAGE
 
-class Message(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
-  DESCRIPTOR = _MESSAGE
-
+Message = _reflection.GeneratedProtocolMessageType('Message', (_message.Message,), dict(
+  DESCRIPTOR = _MESSAGE,
+  __module__ = 'wa_pb2'
   # @@protoc_insertion_point(class_scope:com.whatsapp.proto.Message)
+  ))
+_sym_db.RegisterMessage(Message)
 
-class SenderKeyDistributionMessage(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
-  DESCRIPTOR = _SENDERKEYDISTRIBUTIONMESSAGE
-
+SenderKeyDistributionMessage = _reflection.GeneratedProtocolMessageType('SenderKeyDistributionMessage', (_message.Message,), dict(
+  DESCRIPTOR = _SENDERKEYDISTRIBUTIONMESSAGE,
+  __module__ = 'wa_pb2'
   # @@protoc_insertion_point(class_scope:com.whatsapp.proto.SenderKeyDistributionMessage)
+  ))
+_sym_db.RegisterMessage(SenderKeyDistributionMessage)
 
-class ImageMessage(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
-  DESCRIPTOR = _IMAGEMESSAGE
-
+ImageMessage = _reflection.GeneratedProtocolMessageType('ImageMessage', (_message.Message,), dict(
+  DESCRIPTOR = _IMAGEMESSAGE,
+  __module__ = 'wa_pb2'
   # @@protoc_insertion_point(class_scope:com.whatsapp.proto.ImageMessage)
+  ))
+_sym_db.RegisterMessage(ImageMessage)
 
-class VideoMessage(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
-  DESCRIPTOR = _VIDEOMESSAGE
-
+VideoMessage = _reflection.GeneratedProtocolMessageType('VideoMessage', (_message.Message,), dict(
+  DESCRIPTOR = _VIDEOMESSAGE,
+  __module__ = 'wa_pb2'
   # @@protoc_insertion_point(class_scope:com.whatsapp.proto.VideoMessage)
+  ))
+_sym_db.RegisterMessage(VideoMessage)
 
-class AudioMessage(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
-  DESCRIPTOR = _AUDIOMESSAGE
-
+AudioMessage = _reflection.GeneratedProtocolMessageType('AudioMessage', (_message.Message,), dict(
+  DESCRIPTOR = _AUDIOMESSAGE,
+  __module__ = 'wa_pb2'
   # @@protoc_insertion_point(class_scope:com.whatsapp.proto.AudioMessage)
+  ))
+_sym_db.RegisterMessage(AudioMessage)
 
-class LocationMessage(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
-  DESCRIPTOR = _LOCATIONMESSAGE
-
+LocationMessage = _reflection.GeneratedProtocolMessageType('LocationMessage', (_message.Message,), dict(
+  DESCRIPTOR = _LOCATIONMESSAGE,
+  __module__ = 'wa_pb2'
   # @@protoc_insertion_point(class_scope:com.whatsapp.proto.LocationMessage)
+  ))
+_sym_db.RegisterMessage(LocationMessage)
 
-class DocumentMessage(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
-  DESCRIPTOR = _DOCUMENTMESSAGE
-
+DocumentMessage = _reflection.GeneratedProtocolMessageType('DocumentMessage', (_message.Message,), dict(
+  DESCRIPTOR = _DOCUMENTMESSAGE,
+  __module__ = 'wa_pb2'
   # @@protoc_insertion_point(class_scope:com.whatsapp.proto.DocumentMessage)
+  ))
+_sym_db.RegisterMessage(DocumentMessage)
 
-class UrlMessage(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
-  DESCRIPTOR = _URLMESSAGE
-
+UrlMessage = _reflection.GeneratedProtocolMessageType('UrlMessage', (_message.Message,), dict(
+  DESCRIPTOR = _URLMESSAGE,
+  __module__ = 'wa_pb2'
   # @@protoc_insertion_point(class_scope:com.whatsapp.proto.UrlMessage)
+  ))
+_sym_db.RegisterMessage(UrlMessage)
 
-class ContactMessage(_message.Message):
-  __metaclass__ = _reflection.GeneratedProtocolMessageType
-  DESCRIPTOR = _CONTACTMESSAGE
-
+ContactMessage = _reflection.GeneratedProtocolMessageType('ContactMessage', (_message.Message,), dict(
+  DESCRIPTOR = _CONTACTMESSAGE,
+  __module__ = 'wa_pb2'
   # @@protoc_insertion_point(class_scope:com.whatsapp.proto.ContactMessage)
+  ))
+_sym_db.RegisterMessage(ContactMessage)
 
 
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
Set protobuf syntax to proto2 and fix type issue where a str was being set where bytes were expected on proto message.

Before this change, I was getting errors described in this issue:
https://github.com/tgalal/yowsup/issues/1971